### PR TITLE
Fix jQUDT dependency to grab from maven instead of Github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,5 @@
 FROM maven:3-jdk-8-alpine as maven
 
-WORKDIR /jqudt
-
-RUN apk update && apk add git
-
-RUN git clone https://github.com/egonw/jqudt.git
-
-WORKDIR /jqudt/jqudt 
-
-RUN mvn install 
-
 WORKDIR /tmp
 
 COPY pom.xml .

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 	<dependency>
 	    <groupId>com.github.egonw</groupId>
 	    <artifactId>jqudt</artifactId>
-	    <version>1.4.0-SNAPSHOT</version>
+	    <version>1.4.0</version>
 	</dependency>
   </dependencies>
   <properties>


### PR DESCRIPTION
Fix jQUDT dependency to grab from maven instead of Github